### PR TITLE
feat(jellyfin): cap remote client streaming bitrate at 150 Mbps

### DIFF
--- a/Terraform/apps/jellyfin.tf
+++ b/Terraform/apps/jellyfin.tf
@@ -81,3 +81,7 @@ resource "jellyfin_encoding_configuration" "this" {
   enable_throttling       = true
   enable_segment_deletion = true
 }
+
+resource "jellyfin_system_configuration" "this" {
+  remote_client_bitrate_limit = 150000000
+}


### PR DESCRIPTION
Was 500 Mbps. Applied and verified live (`system.xml` now reads `150000000`).

`jellyfin_system_configuration` is an overlay resource — unset attributes are skipped rather than written — so this touches only `RemoteClientBitrateLimit` and leaves the rest of the server config alone. Plan confirmed: `1 to add, 0 to change, 0 to destroy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)