### PR TITLE
Import Google profile pictures as Authentik avatars

### DIFF
--- a/Terraform/apps/authentik.tf
+++ b/Terraform/apps/authentik.tf
@@ -6,10 +6,6 @@ data "authentik_flow" "default-invalidation-flow" {
   slug = "default-provider-invalidation-flow"
 }
 
-data "authentik_flow" "default-source-authentication" {
-  slug = "default-source-authentication"
-}
-
 data "authentik_certificate_key_pair" "default" {
   name = "authentik Self-signed Certificate"
 }
@@ -46,9 +42,42 @@ resource "authentik_flow_stage_binding" "google_enrollment_write" {
   order  = 10
 }
 
+# The stock default-source-authentication flow only logs the user in, so mapped
+# properties are recomputed each login and discarded. The user_write below is what
+# persists them, which also refreshes name and email from Google on every sign-in.
+resource "authentik_flow" "google_source_auth" {
+  name               = "google-source-authentication"
+  title              = "Sign in with Google"
+  slug               = "google-source-authentication"
+  designation        = "authentication"
+  policy_engine_mode = "any"
+}
+
+# never_create: this flow only ever runs with an already-linked user pending, and
+# create_when_required would silently enroll around the enrollment flow.
+resource "authentik_stage_user_write" "google_source_auth" {
+  name               = "google-auth-user-write"
+  user_creation_mode = "never_create"
+}
+
+resource "authentik_flow_stage_binding" "google_source_auth_write" {
+  target = authentik_flow.google_source_auth.uuid
+  stage  = authentik_stage_user_write.google_source_auth.id
+  order  = 10
+}
+
+resource "authentik_stage_user_login" "google_source_auth" {
+  name = "google-auth-user-login"
+}
+
+resource "authentik_flow_stage_binding" "google_source_auth_login" {
+  target = authentik_flow.google_source_auth.uuid
+  stage  = authentik_stage_user_login.google_source_auth.id
+  order  = 20
+}
+
 # Authentik's Google source type forwards only email and name from userinfo, so the
-# `picture` claim is dropped unless a mapping keeps it. Mappings run at login, so
-# existing users get an avatar on their next sign-in, not on apply.
+# `picture` claim is dropped unless a mapping keeps it.
 resource "authentik_property_mapping_source_oauth" "google_avatar" {
   name       = "google-avatar"
   expression = <<-EOT
@@ -64,7 +93,7 @@ resource "authentik_source_oauth" "google" {
 
   name                = "Google"
   slug                = "google"
-  authentication_flow = data.authentik_flow.default-source-authentication.id
+  authentication_flow = authentik_flow.google_source_auth.uuid
   enrollment_flow     = authentik_flow.google_enrollment.uuid
 
   provider_type   = "google"

--- a/Terraform/apps/authentik.tf
+++ b/Terraform/apps/authentik.tf
@@ -51,6 +51,9 @@ resource "authentik_flow" "google_source_auth" {
   slug               = "google-source-authentication"
   designation        = "authentication"
   policy_engine_mode = "any"
+  # Matches the stock source-authentication flow this replaces; without it an
+  # already-signed-in user can re-enter the login flow.
+  authentication = "require_unauthenticated"
 }
 
 # never_create: this flow only ever runs with an already-linked user pending, and

--- a/Terraform/apps/authentik.tf
+++ b/Terraform/apps/authentik.tf
@@ -46,6 +46,16 @@ resource "authentik_flow_stage_binding" "google_enrollment_write" {
   order  = 10
 }
 
+# Authentik's Google source type forwards only email and name from userinfo, so the
+# `picture` claim is dropped unless a mapping keeps it. Mappings run at login, so
+# existing users get an avatar on their next sign-in, not on apply.
+resource "authentik_property_mapping_source_oauth" "google_avatar" {
+  name       = "google-avatar"
+  expression = <<-EOT
+    return {"attributes": {"avatar": info.get("picture")}}
+  EOT
+}
+
 resource "authentik_source_oauth" "google" {
   access_token_url  = "https://oauth2.googleapis.com/token"
   authorization_url = "https://accounts.google.com/o/oauth2/v2/auth"
@@ -64,6 +74,14 @@ resource "authentik_source_oauth" "google" {
   promoted            = true
   user_matching_mode  = "email_link"
   group_matching_mode = "identifier"
+
+  property_mappings = [authentik_property_mapping_source_oauth.google_avatar.id]
+}
+
+# Tried left to right per user: the Google picture once the mapping has captured one,
+# Gravatar for accounts that have not signed in since, generated initials otherwise.
+resource "authentik_system_settings" "default" {
+  avatars = "attributes.avatar,gravatar,initials"
 }
 
 # The owner must have logged in via Google at least once. Until then the lookup


### PR DESCRIPTION
## Why

Authentik was never importing Google profile pictures. `GoogleType.get_base_user_properties` builds user properties from the `email` and `name` claims only, so the `picture` claim in Google's userinfo response was discarded, and the Google source had no property mappings attached.

No user had an avatar attribute. Every avatar on the instance came from the `gravatar,initials` chain — which is why accounts that happen to have a Gravatar looked "imported" and the rest fell through to generated initials.

## What changed

- `authentik_property_mapping_source_oauth.google_avatar` keeps `picture` in `attributes.avatar`, attached to the Google source.
- `authentik_system_settings.default` puts `attributes.avatar` in front of the existing chain, so Gravatar and initials stay as fallbacks.
- A `google-source-authentication` flow runs a `user_write` before the login stage. The mapping alone only reaches a user during *enrollment*: `SourceFlowManager.handle_auth` computes the mapped properties into the flow's prompt context and then runs the source's authentication flow, and the stock `default-source-authentication` flow holds a `user_login` stage only. With nothing to write them the properties were discarded, so no existing user would ever have gained an avatar.

The write stage is `never_create` — the flow only runs with an already-linked user pending, and `create_when_required` would enroll around the enrollment flow. The flow carries `require_unauthenticated` to match the stock flow it replaces.

## Verification

Applied to the live instance with `-target` on the eight resources; a re-plan of those resources reports `No changes`. Read back from the running server:

| Setting | Live value |
|---|---|
| `avatars` | `attributes.avatar,gravatar,initials` |
| Google source auth flow | `google-source-authentication` |
| Google source mappings | `google-avatar` |
| Flow stages | `[10] user-write (never_create)`, `[20] user-login` |
| Flow requirement | `require_unauthenticated` |

The mapping was dry-run against the real source with a sample Google payload: it produced `{'attributes': {'avatar': '...'}}`, and merging that onto a real user's attributes preserved `goauthentik.io/user/sources`. Nothing was saved in that check.

## Notes

- **Side effect:** name and email now refresh from Google on every sign-in. Username is untouched — the Google source type does not map it.
- **No backfill.** Existing users pick up an avatar on their next sign-in. Stored OAuth access tokens have all expired and Google issued no refresh tokens, and OAuth sources have no sync job.
- Applied with `-target`, so unrelated drift elsewhere in this root is unchecked; CI's untargeted plan may surface some.

🤖 Generated with [Claude Code](https://claude.com/claude-code)